### PR TITLE
Responsive background team section to fix overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -181,6 +181,7 @@ a:hover {
 
 .grey-box {
     background-color: #F5F5F5;
+    height: auto;
 }
 
 .text-l {


### PR DESCRIPTION
I have added height: auto to the .grey-box class which seems to override the section height: 100vh property and solve the overflow issue.